### PR TITLE
Update cl_main.lua

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -28,7 +28,7 @@ Citizen.CreateThread(function()
     TriggerServerEvent("redemrp_inventory:playerJoined")
     while true do
         Wait(1)
-        if IsControlJustReleased(0, 0x4CC0E2FE) then
+        if IsDisabledControlJustReleased(0, 0x4CC0E2FE) then
             if LockerZone then
                 TriggerServerEvent("redemrp_inventory:GetLocker", LockerZone)
             else


### PR DESCRIPTION
When some prompt has active then some keys are not usable. So if you use this way("IsDisabledControlJustReleased") problem is solved.

for example. 
if you use "I" key for open inventory and at the same time, when you use this key("0xDEB34313") for prompt then "I" key not working.