### PR TITLE
Fix display money when using 0.00 values.

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -192,12 +192,12 @@ end)
 
 RegisterNetEvent("redem:addMoney")
 AddEventHandler("redem:addMoney", function(_money)
-    PlayerMoney = _money
+    PlayerMoney = tonumber(string.format("%.2f",tostring(_money)))
 end)
 
 RegisterNetEvent("redem:activateMoney")
 AddEventHandler("redem:activateMoney", function(_money)
-    PlayerMoney = _money
+    PlayerMoney = tonumber(string.format("%.2f",tostring(_money)))
 end)
 
 RegisterNUICallback('additem', function(data)


### PR DESCRIPTION
The roundme function used in redemrp is not correct in this case. It will sometimes display wrong numbers.